### PR TITLE
Add mechanism to keep ApiKey out of git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.userosscache
 *.sln.docstates
 
+apikey.txt
 published.zip
 
 # User-specific files (MonoDevelop/Xamarin Studio)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: publish upload
 
-# Also put the API key in Program.cs
-APIKEY := API_KEY
+FILE := apikey.txt
+APIKEY := $(shell cat ${FILE})
 
 all: help
 

--- a/OnitamaTestClient.csproj
+++ b/OnitamaTestClient.csproj
@@ -6,10 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="apikey.txt" />
     <None Remove="bot.conf" />
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="apikey.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="bot.conf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Reflection;
 using System.Threading;
 using OnitamaTestClient.Models.Enums;
 using RemoteBotClient;
@@ -6,7 +8,10 @@ using RemoteBotClient;
 namespace OnitamaTestClient
 {
     class Program {
-        private const string ApiKey = "API_KEY";
+        private static readonly string ApiKey = File.ReadAllText(Path.Combine(
+            Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+            "apikey.txt"
+        )).Trim();
 
         static void Main(string[] args)
         {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
  - Clone or fork this repository
  - Create an account on https://botchallenge.intern.infi.nl/
  - Create a bot for the Onitama game on https://botchallenge.intern.infi.nl/bots/create
- - Copy the API key and paste it in Program.cs and the Makefile
+ - Copy the API key and save it to a new file `apikey.txt` in the root (it's in the `.gitignore` file so you don't have to worry about accidentally committing it)
  - You can now start your first match!
 
 ## Starting a match
@@ -20,15 +20,14 @@ Each match that is ran can be played back visually from the matches overview.
 
 Requirements: `dotnet`, `make` and `zip`. 
 
-Deploying is as easy as running `make publish` from the commandline. Make sure your bot's API-key is present in the Makefile.
+Deploying is as easy as running `make publish` from the commandline.
 
 ## Publishing your bot on Windows:
 
 We created a powershell script that will do the publishing and zipping for you. 
     
     Run publish.ps1 in powershell (you can find the script in this repo).
-
-Make sure your bot's API-key is present in the Powershell file's `$APIKEY` variable, or else you will get a 404 response from the server. 
+ 
 
 ## bot.conf
 

--- a/publish.ps1
+++ b/publish.ps1
@@ -1,4 +1,4 @@
-$APIKEY = "YOUR_KEY_HERE"
+$APIKEY = (Get-Content ./apikey.txt).Trim()
 
 $sourcePath = ($PSScriptRoot + "/publish")
 $targetPath = ($PSScriptRoot + "/published.zip")


### PR DESCRIPTION
If you want to make your bot's source code public, you still want to keep your Api Key to yourself. This change lets you.

PS. The Makefile part is untested, based on https://stackoverflow.com/a/6779306/419956 so I'm guessing it'll work. Perhaps someone else could verify?